### PR TITLE
Modified RDS DB Engine version

### DIFF
--- a/CloudFormation.yaml
+++ b/CloudFormation.yaml
@@ -131,7 +131,7 @@ Resources:
       DBInstanceClass: db.t2.micro
       AllocatedStorage: 20
       Engine: MySQL
-      EngineVersion: 5.7.28
+      EngineVersion: 5.7.33
       MasterUsername: !Ref MasterUsername
       MasterUserPassword: !Ref MasterPassword
       DBParameterGroupName: !Ref RDSParameterGroup


### PR DESCRIPTION
*Issue #, if available:*
The RDS MySQL DB EngineVersion is old and not available in the RDS console and hence the CLoudFormation Stack rollback.

*Description of changes:*
Modified the EngineVersion from 5.7.28 to 5.7.33.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
